### PR TITLE
fix: transpile issues with https redirect

### DIFF
--- a/packages/nestjs-https-redirect/.babelrc
+++ b/packages/nestjs-https-redirect/.babelrc
@@ -1,0 +1,15 @@
+{
+    "presets": [
+        [
+            "@babel/preset-env",
+            {
+                "targets": {
+                    "esmodules": true
+                }
+            }
+        ],
+    ],
+    "plugins": [
+        "@babel/plugin-proposal-class-properties"
+    ]
+}

--- a/packages/nestjs-https-redirect/tsconfig.json
+++ b/packages/nestjs-https-redirect/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["dom", "esnext"],
     "importHelpers": true,
     "sourceMap": true,
-    "rootDir": "./",
+    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
@@ -25,7 +25,6 @@
     "paths": {
       "*": ["src/*", "node_modules/*"]
     },
-    "jsx": "react",
     "esModuleInterop": true
   }
 }


### PR DESCRIPTION
fix transpile issues with https redirect module.
Previously although no compile errors, the request just froze (with both enabled set to true or false for the middleware)