### PR TITLE
fix: make https redir public

### DIFF
--- a/packages/nestjs-https-redirect/CHANGELOG.md
+++ b/packages/nestjs-https-redirect/CHANGELOG.md
@@ -1,16 +1,5 @@
 # 1.0.0 (2021-01-15)
 
-
-### Bug Fixes
-
-* fix permissions ([#3](https://github.com/kittgen/kittgen-nestjs/issues/3)) ([c3e5ac0](https://github.com/kittgen/kittgen-nestjs/commit/c3e5ac025ba18b1167e7453b1be28b5d5a294f0f))
-* streamlined api ([071db08](https://github.com/kittgen/kittgen-nestjs/commit/071db0817da7e2ee0a36ac8da26e13d5948e56ff))
-
-
 ### Features
 
-* add conditional actions ([#8](https://github.com/kittgen/kittgen-nestjs/issues/8)) ([d787f20](https://github.com/kittgen/kittgen-nestjs/commit/d787f208e2dcd351215ae6bb9c3bb14118e0cf46))
-* add ExposeWithPermission decorator ([#10](https://github.com/kittgen/kittgen-nestjs/issues/10)) ([5ed50c2](https://github.com/kittgen/kittgen-nestjs/commit/5ed50c24fbd7a1e27118e4962693a97f79b49f1a))
-* add extractors for params and query ([#14](https://github.com/kittgen/kittgen-nestjs/issues/14)) ([2ae1f78](https://github.com/kittgen/kittgen-nestjs/commit/2ae1f786aaac0ecef0dc44c07dc494b82cde0c7c))
-* add https middleware package ([#16](https://github.com/kittgen/kittgen-nestjs/issues/16)) ([b2cc3cf](https://github.com/kittgen/kittgen-nestjs/commit/b2cc3cf0138cae7b8e8c42123400d8115dce623d))
-* initial release ([12c7f95](https://github.com/kittgen/kittgen-nestjs/commit/12c7f95829841985bb981a4df9ae9deb109033b6))
+- add https middleware package ([#16](https://github.com/kittgen/kittgen-nestjs/issues/16)) ([b2cc3cf](https://github.com/kittgen/kittgen-nestjs/commit/b2cc3cf0138cae7b8e8c42123400d8115dce623d))

--- a/packages/nestjs-https-redirect/package.json
+++ b/packages/nestjs-https-redirect/package.json
@@ -5,6 +5,9 @@
   "author": "Ottgar",
   "private": false,
   "description": "Kittgen HTTPS redirect middleware for NestJS.",
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "https",
     "redirect",


### PR DESCRIPTION
Configure `publishConfig` and remove obsolete entries in changelog