### PR TITLE
ci(authz): remove custom npmrc step

### DIFF
--- a/.github/workflows/release-nestjs-authorization.yml
+++ b/.github/workflows/release-nestjs-authorization.yml
@@ -55,14 +55,10 @@ jobs:
           CI: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run build
-      - name: Create .npmrc
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Release
         if: success()
         env:
           CI: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: 'npx semantic-release'


### PR DESCRIPTION
we can use `NODE_AUTH_TOKEN` instead