### PR TITLE
fix(authz): handle null/undefined in interceptor

### DIFF
--- a/packages/nestjs-authorization/src/permissions/permission.interceptor.spec.ts
+++ b/packages/nestjs-authorization/src/permissions/permission.interceptor.spec.ts
@@ -206,5 +206,61 @@ describe('PermissionInterceptor', () => {
       expect(dto).toHaveProperty('quux');
       expect(dto).not.toHaveProperty('dtos');
     });
+
+    it('should not fail on null without permission', async () => {
+      const callHandler = mockCallHandler(
+        new TestDto(null as any, null as any)
+      );
+      const interceptor = createPermissionInterceptor();
+
+      const dto = await interceptor
+        .intercept(createMockContext(), callHandler)
+        .toPromise();
+
+      expect(dto).not.toHaveProperty('foo');
+      expect(dto).toHaveProperty('bar');
+    });
+
+    it('should not fail on null with permission', async () => {
+      const callHandler = mockCallHandler(
+        new TestDto(null as any, null as any)
+      );
+      const interceptor = createPermissionInterceptor('can-read-foo');
+
+      const dto = await interceptor
+        .intercept(createMockContext(), callHandler)
+        .toPromise();
+
+      expect(dto).toHaveProperty('foo');
+      expect(dto).toHaveProperty('bar');
+    });
+
+    it('should not fail on undefined without permission', async () => {
+      const callHandler = mockCallHandler(
+        new TestDto(undefined as any, undefined as any)
+      );
+      const interceptor = createPermissionInterceptor();
+
+      const dto = await interceptor
+        .intercept(createMockContext(), callHandler)
+        .toPromise();
+
+      expect(dto).not.toHaveProperty('foo');
+      expect(dto).toHaveProperty('bar');
+    });
+
+    it('should not fail on undefined with permission', async () => {
+      const callHandler = mockCallHandler(
+        new TestDto(undefined as any, undefined as any)
+      );
+      const interceptor = createPermissionInterceptor('can-read-foo');
+
+      const dto = await interceptor
+        .intercept(createMockContext(), callHandler)
+        .toPromise();
+
+      expect(dto).toHaveProperty('foo');
+      expect(dto).toHaveProperty('bar');
+    });
   });
 });

--- a/packages/nestjs-authorization/src/permissions/permission.interceptor.ts
+++ b/packages/nestjs-authorization/src/permissions/permission.interceptor.ts
@@ -23,6 +23,9 @@ const deepForEach = async (
   obj: Record<string, any>,
   fn: (value: any) => Promise<any>
 ): Promise<Record<string, any>> => {
+  if (obj == null) {
+    return obj;
+  }
   const updatedObj = await fn(obj);
   return Object.keys(updatedObj).reduce(async (acc, key) => {
     const updated = await acc;
@@ -42,7 +45,7 @@ const removeProps = (
   permissionService: PermissionService,
   context: ExecutionContext
 ) => async (data: any): Promise<any> => {
-  if (typeof data !== 'object') {
+  if (typeof data !== 'object' || data == null) {
     return;
   }
   const props =
@@ -51,9 +54,12 @@ const removeProps = (
   return await props.reduce(
     async (result: any, [prop, action]: [string, Action]) => {
       const res = await result;
-      if (
-        !(await permissionService.areAllowed([action], permissionSet, context))
-      ) {
+      const allowed = await permissionService.areAllowed(
+        [action],
+        permissionSet,
+        context
+      );
+      if (!allowed) {
         delete res[prop];
       }
       return res;


### PR DESCRIPTION
Let interceptor handle `null` and `undefined` values, such that it does not fail with an exception.