### PR TITLE
fix(authz): let deepForEach handle non-objects

### DIFF
--- a/packages/nestjs-authorization/src/permissions/permission.interceptor.spec.ts
+++ b/packages/nestjs-authorization/src/permissions/permission.interceptor.spec.ts
@@ -262,5 +262,16 @@ describe('PermissionInterceptor', () => {
       expect(dto).toHaveProperty('foo');
       expect(dto).toHaveProperty('bar');
     });
+
+    it('should not fail on non-object values', async () => {
+      const callHandler = mockCallHandler(false as any);
+      const interceptor = createPermissionInterceptor('can-read-foo');
+
+      const dto = await interceptor
+        .intercept(createMockContext(), callHandler)
+        .toPromise();
+
+      expect(dto).toBeFalsy();
+    });
   });
 });

--- a/packages/nestjs-authorization/src/permissions/permission.interceptor.ts
+++ b/packages/nestjs-authorization/src/permissions/permission.interceptor.ts
@@ -23,7 +23,7 @@ const deepForEach = async (
   obj: Record<string, any>,
   fn: (value: any) => Promise<any>
 ): Promise<Record<string, any>> => {
-  if (obj == null) {
+  if (typeof obj !== 'object' || obj == null) {
     return obj;
   }
   const updatedObj = await fn(obj);


### PR DESCRIPTION
Return immediately if non-objects are being handled