### PR TITLE
fix(hist): failure if no `MappedColumn`s

### DIFF
--- a/packages/nestjs-typeorm-history/src/history-subscriber.ts
+++ b/packages/nestjs-typeorm-history/src/history-subscriber.ts
@@ -26,23 +26,23 @@ export const createHistorySubscriber = <E, H extends Record<string, any>>(
 @EventSubscriber()
 export class HistoryEntitySubscriber<E, H extends Record<string, any>>
   implements HistoryEntitySubscriberInterface<E, H> {
-  constructor(readonly entity: Function, readonly historyEntity: Function) {}
+  constructor(readonly entity: Function, readonly historyEntity: Function) { }
 
   public beforeInsertHistory(history: H): H | Promise<H> {
     return history;
   }
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-  public afterInsertHistory(_history: H): void | Promise<void> {}
+  public afterInsertHistory(_history: H): void | Promise<void> { }
   public beforeUpdateHistory(history: H): H | Promise<H> {
     return history;
   }
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-  public afterUpdateHistory(_history: H): void | Promise<void> {}
+  public afterUpdateHistory(_history: H): void | Promise<void> { }
   public beforeRemoveHistory(history: H): H | Promise<H> {
     return history;
   }
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
-  public afterRemoveHistory(_history: H): void | Promise<void> {}
+  public afterRemoveHistory(_history: H): void | Promise<void> { }
 
   public listenTo(): Function {
     return this.entity;
@@ -54,7 +54,7 @@ export class HistoryEntitySubscriber<E, H extends Record<string, any>>
   ): H | Promise<H> {
     const e: E = manager.create(this.entity, entity);
     const hist: H = manager.create(this.historyEntity);
-    const props = Reflect.getMetadata(TYPEORM_HISTORY_MAPPED_COLUMNS, hist);
+    const props = Reflect.getMetadata(TYPEORM_HISTORY_MAPPED_COLUMNS, hist) || [];
     const snapshotProp = Reflect.getMetadata(
       TYPEORM_HISTORY_SNAPSHOT_COLUMN,
       hist


### PR DESCRIPTION
Fixes an `undefined` `TypeError` if no `MappedColumn` exist in the history entity